### PR TITLE
Check area of input AOI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+*.tif
+tests/debug.ipynb
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ example = "pdal_pipeline create-dsm  notebooks/uw-campus.geojson notebooks/UTM_1
 test = "pytest"
 typecheck = "mypy src/lidar_tools/"
 lint = "ruff check src/lidar_tools/ --fix ; ruff format"
-test-create-dsm = "pdal_pipeline create-dsm  notebooks/uw-campus.geojson notebooks/UTM_10N_WGS84_G2139_3D.wkt /tmp/dem"
+test-create-dsm = "time pdal_pipeline create-dsm  notebooks/uw-campus.geojson notebooks/UTM_10N_WGS84_G2139_3D.wkt /tmp/dem --no-cleanup"
 
 [tool.pixi.dependencies]
 cyclopts = "*"

--- a/src/lidar_tools/__init__.py
+++ b/src/lidar_tools/__init__.py
@@ -1,6 +1,6 @@
-from lidar_tools import filter_percentile, dsm_functions
+from lidar_tools import filter_percentile, dsm_functions, pdal_pipeline
 from importlib.metadata import version as _version
 
 __version__ = _version("lidar_tools")
 
-__all__ = ["filter_percentile", "dsm_functions"]
+__all__ = ["filter_percentile", "dsm_functions", "pdal_pipeline"]

--- a/src/lidar_tools/pdal_pipeline.py
+++ b/src/lidar_tools/pdal_pipeline.py
@@ -14,9 +14,12 @@ from lidar_tools import dsm_functions
 import pdal
 from pyproj import CRS
 from shapely.geometry import Polygon
+from shapely.geometry.polygon import orient as _orient
 import geopandas as gpd
+import numpy as np
 import json
 from pathlib import Path
+import warnings
 
 # NOTE: Hardcoding global settings for now, can expose as script arguments later
 # -------------------------------------------------------
@@ -83,8 +86,9 @@ def create_dsm(
 
     # bounds for which pointcloud is created
     gdf = gpd.read_file(extent_polygon)
-    xmin, ymin, xmax, ymax = gdf.total_bounds
+    _check_polygon_area(gdf)
 
+    xmin, ymin, xmax, ymax = gdf.total_bounds
     input_aoi = Polygon.from_bounds(xmin, ymin, xmax, ymax)
     input_crs = gdf.crs.to_wkt()
 
@@ -329,3 +333,68 @@ def create_dsm(
             os.remove(dtm_mos_fn)
         if os.path.exists(intensity_mos_fn):
             os.remove(intensity_mos_fn)
+
+
+def geographic_area(gf: gpd.GeoDataFrame) -> gpd.pd.Series:
+    """
+    Estimate the geographic area of each polygon in a GeoDataFrame in m^2
+
+    Parameters
+    ----------
+    gf : gpd.GeoDataFrame
+        A GeoDataFrame containing the geometries for which the area needs to be calculated. The GeoDataFrame
+        must have a geographic coordinate system (latitude and longitude).
+
+    Returns
+    -------
+    pd.Series
+        A Pandas Series containing the area of each polygon in the input GeoDataFrame in m^2.
+
+    Raises
+    ------
+    TypeError
+        If the GeoDataFrame does not have a geographic coordinate system.
+
+    Notes
+    ----------
+    - Only works for areas up to 1/2 of globe (https://github.com/pyproj4/pyproj/issues/1401)
+    """
+    if gf.crs is None or not gf.crs.is_geographic:
+        msg = "This function requires a GeoDataFrame with gf.crs.is_geographic==True"
+        raise TypeError(msg)
+
+    geod = gf.crs.get_geod()
+
+    def area_calc(geom):
+        if geom.geom_type not in ["MultiPolygon", "Polygon"]:
+            return np.nan
+
+        # For MultiPolygon do each separately
+        if geom.geom_type == "MultiPolygon":
+            return np.sum([area_calc(p) for p in geom.geoms])
+
+        # orient to ensure a counter-clockwise traversal.
+        # geometry_area_perimeter returns (area, perimeter)
+        return geod.geometry_area_perimeter(_orient(geom, 1))[0]
+
+    return gf.geometry.apply(area_calc)
+
+
+def _check_polygon_area(gf: gpd.GeoDataFrame) -> None:
+    """
+    Issue a warning if area is bigger than threshold
+    """
+    warn_if_larger_than = 100_000  # km^2
+
+    # Fast track if projected and units are meters:
+    if gf.crs.is_projected and gf.crs.axis_info[0].unit_name == "metre":
+        area = gf.area * 1e-6
+    else:
+        area = geographic_area(gf.to_crs("EPSG:4326")) * 1e-6
+
+    print(area.values[0])
+    if area.to_numpy() >= warn_if_larger_than:
+        msg = f"Very large AOI ({area.values[0]:e} km^2) requested, processing may be slow or crash. Recommended AOI size is <{warn_if_larger_than:e} km^2"
+        warnings.warn(msg)
+    else:
+        print(f"Starting Processing of {area.values[0]:e} km^2 AOI")

--- a/tests/test_pdal_pipeline.py
+++ b/tests/test_pdal_pipeline.py
@@ -1,0 +1,38 @@
+import lidar_tools
+import geopandas as gpd
+from shapely.geometry import Polygon
+import pyproj
+import numpy as np
+import pytest
+
+
+@pytest.fixture
+def small_aoi(scope="package"):
+    # 5 vertices bounding box around UW Campus 3.5 km^2
+    aoi_url = "./notebooks/uw-campus.geojson"
+    return gpd.read_file(aoi_url)
+
+
+def test_check_geographic_area(small_aoi):
+    area = lidar_tools.pdal_pipeline.geographic_area(small_aoi)
+    expected = 3488698
+    actual = area.to_numpy().astype(np.int32)
+    assert expected == actual
+
+
+def test_check_large_aoi_warns_geographic():
+    # NOTE: computation only works for a hemisphere
+    bounds = (0, -90, 180.0, 90)
+    polygon = Polygon.from_bounds(*bounds)
+    gf = gpd.GeoDataFrame({"geometry": [polygon]}, crs="EPSG:4326")
+    with pytest.warns(match="Very large AOI"):
+        lidar_tools.pdal_pipeline._check_polygon_area(gf)
+
+
+def test_check_large_aoi_warns_projected():
+    # NOTE: computation only works for a hemisphere
+    bounds = (0, 0, 100_001e3, 1e3)
+    polygon = Polygon.from_bounds(*bounds)
+    gf = gpd.GeoDataFrame({"geometry": [polygon]}, crs="EPSG:32610")
+    with pytest.warns(match="Very large AOI"):
+        lidar_tools.pdal_pipeline._check_polygon_area(gf)


### PR DESCRIPTION
Partially Addresses #16

I started exploring parallelizing the processing. Currently, the code *always divides the AOI* into 25 tiles regardless of the total AOI size:

https://github.com/uw-cryo/lidar_tools/blob/4a5610f66fc91f9e196d270476510482f7cddb33/src/lidar_tools/pdal_pipeline.py#L102-L103

As a second step, I'd like to make these configurable (or automatically adjust based on passed AOI area and output grid resolution). But I think this first step is useful to add as-is :) 