### PR TITLE
Expose filters to remove noise when creating DSM and intensity maps

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,31 +54,32 @@ Create a Digital Surface Model (DSM), Digital Terrain Model (DTM) and intensity 
 3DEP point cloud data.
 
 ╭─ Parameters ──────────────────────────────────────────────────────────────────────────────────────────────────╮
-│ *  EXTENT-POLYGON --extent-polygon          Path to the polygon file defining the processing extent.          │
-│                                             [required]                                                        │
-│ *  OUTPUT-PREFIX --output-prefix            prefix with directory name and filename prefix for the project    │
-│                                             (e.g., CO_ALS_proc/CO_3DEP_ALS) [required]                        │
-│    TARGET-WKT --target-wkt                  Path to the WKT file defining the target coordinate reference     │
-│                                             system (CRS).                                                     │
-│    LOCAL-UTM --local-utm --no-local-utm     If true, compute the UTM zone from the extent polygon and use it  │
-│                                             to create the output rasters. If false, use the CRS defined in    │
-│                                             the target_wkt file. [default: False]                             │
-│    SOURCE-WKT --source-wkt                  Path to the WKT file defining the source coordinate reference     │
-│                                             system (CRS). If None, the CRS from the point cloud file is used. │
-│    LOCAL-LAZ-DIR --local-laz-dir            If  the path to a local directory containing laz files is         │
-│                                             specified, the laz files are processed. If not specified, the     │
-│                                             function will process USGS 3DEP EPT tiles                         │
+│ *  EXTENT-POLYGON --extent-polygon          Path to the vector dataset containing a polygon defining the      │
+│                                             processing extent. [required]                                     │
+│ *  OUTPUT-PREFIX --output-prefix            Path for output files, containing directory path and filename     │
+│                                             prefix (e.g., /tmp/CO_3DEP_ALS). [required]                       │
+│    TARGET-WKT --target-wkt                  Path to a text file containing WKT2 definition for the output     │
+│                                             coordinate reference system (CRS). If unspecified, a local UTM    │
+│                                             CRS will be used.                                                 │
+│    LOCAL-UTM --local-utm --no-local-utm     If true, automatically compute the local UTM zone from the extent │
+│                                             polygon for final output products. If false, use the CRS defined  │
+│                                             in the target_wkt file. [default: False]                          │
+│    SOURCE-WKT --source-wkt                  Path to a text file containing WKT2 definition for the coordinate │
+│                                             reference system (CRS) of the input point cloud. If unspecified,  │
+│                                             the CRS defined in the source point cloud metadata will be used.  │
+│    LOCAL-LAZ-DIR --local-laz-dir            Path to directory containing source laz point cloud files. If not │
+│                                             specified, the program will process USGS 3DEP EPT tiles.          │
 │    EPT-TILE-SIZE-KM --ept-tile-size-km      The size of the EPT tiles to be processed. This is only used if   │
 │                                             local_laz_dir is not specified. The default is 1.0 km, which      │
 │                                             means that the function will process 1 km x 1 km tiles. If you    │
 │                                             want to process larger tiles, you can specify a larger value.     │
 │                                             [default: 1.0]                                                    │
-│    PROCESS-SPECIFIC-3DEP-SURVEY             If specified, only process the given 3DEP survey. This should be  │
-│      --process-specific-3dep-survey         a string that matches the workunit name in the 3DEP metadata      │
-│    PROCESS-ALL-INTERSECTING-SURVEYS         If true, process all available EPT surveys which intersect with   │
-│      --process-all-intersecting-surveys     the input polygon. If false, and process_specific_3dep_survey is  │
-│      --no-process-all-intersecting-surveys  not specified, only process the first available 3DEP EPT survey   │
-│                                             that intersects the input polygon. [default: False]               │
+│    PROCESS-SPECIFIC-3DEP-SURVEY             Only process the specified 3DEP project name. This should be a    │
+│      --process-specific-3dep-survey         string that matches the workunit name in the 3DEP metadata.       │
+│    PROCESS-ALL-INTERSECTING-SURVEYS         If true, process all available 3DEP EPT point clouds which        │
+│      --process-all-intersecting-surveys     intersect with the input polygon. If false, and                   │
+│      --no-process-all-intersecting-surveys  process_specific_3dep_survey is not specified, first 3DEP project │
+│                                             encountered will be processed. [default: False]                   │
 │    NUM-PROCESS --num-process                Number of processes to use for parallel processing. Default is 1, │
 │                                             which means all pdal and gdal processing will be done serially    │
 │                                             [default: 1]                                                      │

--- a/src/lidar_tools/dsm_functions.py
+++ b/src/lidar_tools/dsm_functions.py
@@ -1153,7 +1153,7 @@ def create_lpc_pipeline(local_laz_dir: str,
             group_filter="first,only",
             reproject=True, # reproject to the output CRS            
             input_crs=input_crs[i],
-            output_crs=out_crs
+            output_crs=out_crs,
             filter_high_noise=filter_high_noise)  
         dsm_stage = create_dem_stage(
             dem_filename=str(dsm_file),
@@ -1235,7 +1235,7 @@ def create_lpc_pipeline(local_laz_dir: str,
                 group_filter="first,only",
                 reproject=True, # reproject to the output CRS            
                 input_crs=input_crs[i],
-                output_crs=out_crs
+                output_crs=out_crs,
                 filter_high_noise=filter_high_noise)
 
         intensity_stage = create_dem_stage(

--- a/src/lidar_tools/pdal_pipeline.py
+++ b/src/lidar_tools/pdal_pipeline.py
@@ -35,6 +35,7 @@ def create_dsm(
     local_utm: bool = False,
     source_wkt: str = None,
     filter_high_noise: bool = True,
+    hag_nn: float = None,
     local_laz_dir: str = None,
     ept_tile_size_km: float = 1.0,
     process_specific_3dep_survey: str = None,
@@ -60,6 +61,8 @@ def create_dsm(
         If true, automatically compute the local UTM zone from the extent polygon for final output products. If false, use the CRS defined in the target_wkt file.
     filter_high_noise: bool
         Remove high noise points (classification==18) from the point cloud before DSM and surface intensity processing. Default is True.
+    hag_nn : float, optional
+        If specified, the height above ground (HAG) will be calculated using all nearest ground classied points, and all points greater than this value will be classified as high noise, by default None.
     local_laz_dir: str
         Path to directory containing source laz point cloud files. If not specified, the program will process USGS 3DEP EPT tiles.
     ept_tile_size_km: float
@@ -138,7 +141,7 @@ def create_dsm(
                                     local_laz_dir=local_laz_dir,
                                     target_wkt=target_wkt,output_prefix=output_prefix,
                                     extent_polygon=extent_polygon,buffer_value=5,
-                                    filter_high_noise=filter_high_noise)
+                                    filter_high_noise=filter_high_noise,hag_nn=hag_nn)
         
     else:
         print("This run will process 3DEP EPT tiles")
@@ -150,7 +153,7 @@ def create_dsm(
                 tile_size_km=ept_tile_size_km,
                 process_specific_3dep_survey=process_specific_3dep_survey,
                 process_all_intersecting_surveys=process_all_intersecting_surveys,
-                filter_high_noise=filter_high_noise)
+                filter_high_noise=filter_high_noise,hag_nn=hag_nn)
         
     if num_process == 1:
         print("Running DSM/DTM/intensity pipelines sequentially")

--- a/src/lidar_tools/pdal_pipeline.py
+++ b/src/lidar_tools/pdal_pipeline.py
@@ -34,6 +34,7 @@ def create_dsm(
     target_wkt: str = None,
     local_utm: bool = False,
     source_wkt: str = None,
+    filter_high_noise: bool = True,
     local_laz_dir: str = None,
     ept_tile_size_km: float = 1.0,
     process_specific_3dep_survey: str = None,
@@ -57,6 +58,8 @@ def create_dsm(
         Path to a text file containing WKT2 definition for the coordinate reference system (CRS) of the input point cloud. If unspecified, the CRS defined in the source point cloud metadata will be used.
     local_utm: bool
         If true, automatically compute the local UTM zone from the extent polygon for final output products. If false, use the CRS defined in the target_wkt file.
+    filter_high_noise: bool
+        Remove high noise points (classification==18) from the point cloud before DSM and surface intensity processing. Default is True.
     local_laz_dir: str
         Path to directory containing source laz point cloud files. If not specified, the program will process USGS 3DEP EPT tiles.
     ept_tile_size_km: float
@@ -134,7 +137,8 @@ def create_dsm(
         intensity_pipeline_list) = dsm_functions.create_lpc_pipeline(
                                     local_laz_dir=local_laz_dir,
                                     target_wkt=target_wkt,output_prefix=output_prefix,
-                                    extent_polygon=extent_polygon,buffer_value=5)
+                                    extent_polygon=extent_polygon,buffer_value=5,
+                                    filter_high_noise=filter_high_noise)
         
     else:
         print("This run will process 3DEP EPT tiles")
@@ -145,7 +149,8 @@ def create_dsm(
                 buffer_value=5,
                 tile_size_km=ept_tile_size_km,
                 process_specific_3dep_survey=process_specific_3dep_survey,
-                process_all_intersecting_surveys=process_all_intersecting_surveys)
+                process_all_intersecting_surveys=process_all_intersecting_surveys
+                filter_high_noise=filter_high_noise)
         
     if num_process == 1:
         print("Running DSM/DTM/intensity pipelines sequentially")

--- a/src/lidar_tools/pdal_pipeline.py
+++ b/src/lidar_tools/pdal_pipeline.py
@@ -149,7 +149,7 @@ def create_dsm(
                 buffer_value=5,
                 tile_size_km=ept_tile_size_km,
                 process_specific_3dep_survey=process_specific_3dep_survey,
-                process_all_intersecting_surveys=process_all_intersecting_surveys
+                process_all_intersecting_surveys=process_all_intersecting_surveys,
                 filter_high_noise=filter_high_noise)
         
     if num_process == 1:


### PR DESCRIPTION
This draft PR exposes the noise filtering scheme as command line options. There are two options:
* Filter out points which are already classified as high-noise 
* Provide an option to remove points whose relative height above ground is higher than a given value. This is applied in addition to high-noise if selected.

The first option was effective in removing the noise from the 3DEP AZ_PIMA PCD site.

<img width="1753" height="2748" alt="AZ_PimaCo_2_2021-DSM_mos_fig (1)" src="https://github.com/user-attachments/assets/5a7eb7a4-d19e-4d3c-8f84-bfeef60d8aef" />
<img width="1770" height="2812" alt="AZ_PimaCo_2_2021-DSM_mos_fig" src="https://github.com/user-attachments/assets/f0115a6d-2d12-4e82-b0e6-36877e35c375" />

The second option was effective in clearing out noise over the Mt. Baker site for the DeepDEM paper.

<img width="1490" height="848" alt="Screenshot 2025-07-10 at 9 36 52 PM" src="https://github.com/user-attachments/assets/128c0be6-81c1-42a6-b85b-ace32dff861b" />
Fig: Note the outliers above the surface in the point cloud.

<img width="2949" height="2527" alt="baker_deepdem_with_filter-DSM_mos_baker_deepdem_no_filter-DSM_mos_diff_fig_stretch_5" src="https://github.com/user-attachments/assets/82267298-b627-44a1-9d17-1ba699d0f525" />
Fig: Difference between the DSM produced using the unfiltered DSM and DSM produced using high-noise and height-above-ground filter of 120m. Note the blue regions which represent errors due to outlier in the gridded DSM.

Todo:
* I want to check the [pdal outlier filters](https://pdal.io/en/stable/stages/filters.outlier.html) as suggested by David before completing the PR! 